### PR TITLE
fix reverse scroll direction

### DIFF
--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -152,7 +152,7 @@ public class InventoryUtils
             moveToOtherInventory = above == scrollingUp;
         }
 
-        if ((Configs.useSlotPositionAwareScrollDirection && isShiftDown == false) ||
+        if ((Configs.reverseScrollDirectionSingle && isShiftDown == false) ||
             (Configs.reverseScrollDirectionStacks && isShiftDown))
         {
             moveToOtherInventory = ! moveToOtherInventory;


### PR DESCRIPTION
This fixes the reverse scrolling direction configuration option for single items not affecting anything (the value was never read in the code). According to the commit history of this project, this line was changed but I can't figure out why, so I think it's a bug, so this fix just changes it back.

Full disclosure: I'm not 100% sure this fix doesn't break anything else, but it definitely fixes being unable to reverse scrolling direction for single items.