### PR TITLE
Add recipe-book optimization to fix crafting in later versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a customized version of Masa's itemscroller mod that fixes crafting features for 1.15.2. Masa's original mod can be found [here](https://github.com/maruohon/itemscroller)
 
 ### What's different?
-Post 1.13, Mojang has changed the crafting mechanics of the game. Before 1.13, crafting was very fast as much of the logic was handled client-side. In 1.13, most of the crafting logic was moved to the server. This broke Itemscroller's fast crafting features, as every ingredient now had to be moved one slot at a time to the crafting grid for it to work. This drastically worsened server-client desync, a compounding problem, which lead to increasing failed crafting attempts and accidental ingredient leaks which made afk crafting impossible. 
+Post 1.13, Mojang has changed the crafting mechanics of the game. Before 1.13, crafting was very fast as much of the logic was handled client-side. In 1.13, most of the crafting logic was moved to the server. This broke Itemscroller's fast crafting features, since every ingredient now had to be moved one slot at a time to the crafting grid for it to work. This drastically worsened server-client desync, a compounding problem, leading to an increasing number of failed crafting attempts and accidental ingredient leaks which made afk crafting impossible. 
 
 This customized version of the mod, fixes the problem by handling ingredient movement server-side using the recipe book protocols when it can.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## Note
+This is a customized version of Masa's itemscroller mod that fixes crafting features for 1.15.2. Masa's original mod can be found [here](https://github.com/maruohon/itemscroller)
+
+### What's different?
+Post 1.13, Mojang has changed the crafting mechanics of the game. Before 1.13, crafting was very fast as much of the logic was handled client-side. In 1.13, most of the crafting logic was moved to the server. This broke Itemscroller's fast crafting features, as every ingredient now had to be moved one slot at a time to the crafting grid for it to work. This drastically worsened server-client desync, a compounding problem, which lead to increasing failed crafting attempts and accidental ingredient leaks which made afk crafting impossible. 
+
+This customized version of the mod, fixes the problem by handling ingredient movement server-side using the recipe book protocols when it can.
+
+
 Item Scroller
 ==============
 Item Scroller is a tiny mod for Minecraft 1.8.9+, which adds the functionality of moving items in inventory GUIs

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.screen.ingame.ContainerScreen;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.container.Slot;
+import net.minecraft.recipe.CraftingRecipe;
 import net.minecraft.sound.SoundEvents;
 import fi.dy.masa.itemscroller.ItemScroller;
 import fi.dy.masa.itemscroller.config.Configs;
@@ -185,8 +186,13 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
 
                 InventoryUtils.tryClearCursor(gui, mc);
                 InventoryUtils.throwAllCraftingResultsToGround(recipe, gui);
-                InventoryUtils.tryMoveItemsToFirstCraftingGrid(recipe, gui, true);
 
+                CraftingRecipe bookRecipe = InventoryUtils.getBookRecipeFromPattern(recipe);
+                if (bookRecipe != null) { // Use recipe book if possible
+                    mc.interactionManager.clickRecipe(mc.player.container.syncId, bookRecipe, true);
+                } else {
+                    InventoryUtils.tryMoveItemsToFirstCraftingGrid(recipe, gui, true);
+                }
                 int failsafe = 0;
 
                 while (++failsafe < 40 && InventoryUtils.areStacksEqual(outputSlot.getStack(), recipe.getResult()))
@@ -202,7 +208,12 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
 
                     InventoryUtils.tryClearCursor(gui, mc);
                     InventoryUtils.throwAllCraftingResultsToGround(recipe, gui);
-                    InventoryUtils.tryMoveItemsToFirstCraftingGrid(recipe, gui, true);
+                    bookRecipe = InventoryUtils.getBookRecipeFromPattern(recipe);
+                    if (bookRecipe != null) { // Use recipe book if possible
+                        mc.interactionManager.clickRecipe(mc.player.container.syncId, bookRecipe, true);
+                    } else {
+                        InventoryUtils.tryMoveItemsToFirstCraftingGrid(recipe, gui, true);
+                    }
                 }
             }
         }

--- a/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
+++ b/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
@@ -38,6 +38,7 @@ public class RecipePattern
             this.recipe[i] = InventoryUtils.EMPTY_STACK;
         }
 
+        this.cachedRecipeFromBook = null;
         this.result = InventoryUtils.EMPTY_STACK;
     }
 

--- a/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
+++ b/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
@@ -7,6 +7,7 @@ import net.minecraft.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.recipe.CraftingRecipe;
 import fi.dy.masa.itemscroller.recipes.CraftingHandler.SlotRange;
 import fi.dy.masa.itemscroller.util.Constants;
 import fi.dy.masa.itemscroller.util.InventoryUtils;
@@ -15,6 +16,7 @@ public class RecipePattern
 {
     private ItemStack result = InventoryUtils.EMPTY_STACK;
     private ItemStack[] recipe = new ItemStack[9];
+    public CraftingRecipe cachedRecipeFromBook = null;
 
     public RecipePattern()
     {


### PR DESCRIPTION
Tested in 1.15.2, and both masscrafting and crafteverything worked without fail.