### PR TITLE
"temporary" port to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.11-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17

--- a/build.properties
+++ b/build.properties
@@ -9,12 +9,12 @@ mod_file_name = itemscroller-fabric
 mod_version = 0.16.0
 
 # Required malilib version
-malilib_version = 0.12.0
+malilib_version = 0.12.2
 
 # Minecraft, Fabric and mappings versions
-minecraft_version_out = 1.18.2
-minecraft_version = 1.18.2
-mappings_version = 1.18.2+build.1
+minecraft_version_out = 1.19
+minecraft_version = 1.19
+mappings_version = 1.19+build.1
 
-fabric_loader_version = 0.13.3
-mod_menu_version = 3.1.0
+fabric_loader_version = 0.14.7
+mod_menu_version = 4.0.0

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
 	],
 
 	"depends": {
-		"minecraft": "1.18.2",
+		"minecraft": ">=1.19",
 		"malilib": "0.12.x"
 	}
 }


### PR DESCRIPTION
Minimally tested to work well enough.

Also see maruohon/malilib#85